### PR TITLE
feat: add isbase64encoded to response

### DIFF
--- a/host/http.ts
+++ b/host/http.ts
@@ -8,6 +8,7 @@ export type Response = {
     headers: { readonly [key: string]: string }
     status: number
     body?: string | Buffer
+    isBase64Encoded?: boolean
 }
 
 type RequestOptions = BodylessRequestOptions | StringRequestOptions | JsonRequestOptions
@@ -152,6 +153,7 @@ function resultToResponse(result: Result, withLogBody: boolean): Response & { lo
                 status: result.status ?? 200,
                 body: result.body,
                 logBody,
+                isBase64Encoded: result.isBase64Encoded,
             }
         } else if (Buffer.isBuffer(result.body)) {
             const logBody = withLogBody ? result.body.toString('base64') : undefined
@@ -160,6 +162,7 @@ function resultToResponse(result: Result, withLogBody: boolean): Response & { lo
                 status: result.status ?? 200,
                 body: result.body,
                 logBody,
+                isBase64Encoded: result.isBase64Encoded,
             }
         } else {
             const logBody = withLogBody ? result.body : undefined

--- a/http.ts
+++ b/http.ts
@@ -12,6 +12,7 @@ export type FullResult = {
     headers?: ResponseHeaders
     status?: number
     body?: unknown
+    isBase64Encoded?: boolean
 }
 
 export type Result = void | string | FullResult


### PR DESCRIPTION
Forward isBase64Encoded to response object

**Motivation**
To be able to output binary from riddance services, we need to forward this property. It could automatically be set, but I am unsure if any services relies on the current behaviour (which is just returning base64 strings)

See https://docs.aws.amazon.com/apigateway/latest/developerguide/lambda-proxy-binary-media.html