### PR TITLE
feat: add rawBody

### DIFF
--- a/context.ts
+++ b/context.ts
@@ -99,6 +99,11 @@ export type HandlerConfiguration = {
    * Any AWS Lambda Layers to be added to the function. An array of ARNs.
    */
   readonly layers?: string[];
+  /**
+   * A boolean indicating whether the request.body should be passed as a raw string to the handler instead of parsed JSON.
+   * @default false
+   */
+  readonly rawBody?: boolean;
 };
 
 export type Context = {


### PR DESCRIPTION
Add `rawBody` to event type

Motivation
Stripe requires the raw request body to verify webhook signatures, and any mutation of the payload can invalidate the signature. This change adds rawBody to the event type to support passing through the original, unparsed body as recommended by [Stripe’s webhook documentation](https://docs.stripe.com/webhooks/signature#retrieve-the-raw-request-body).