### PR TITLE
feat: dont log warnings for <500 requests

### DIFF
--- a/host/http.ts
+++ b/host/http.ts
@@ -91,11 +91,14 @@ export async function executeRequest(
                 body: response.logBody,
             },
         })
-        if (response.status < 300) {
-            log.debug('Request END')
-            await success()
+        if (response.status >= 500) {
+            log.error('Request END')            
         } else {
-            log.warn('Request END')
+            log.debug('Request END')
+        }
+
+        if (response.status < 300) {
+            await success()
         }
         return response
     } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@riddance/host",
-  "version": "0.0.17",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@riddance/host",
-      "version": "0.0.17",
+      "version": "0.0.20",
       "license": "MIT",
       "devDependencies": {
         "@riddance/env": "0.2.9"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@riddance/host",
-  "version": "0.0.17",
+  "version": "0.0.20",
   "type": "module",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
If you `throw badRequest` it will log as `debug`, but if you `return { status: 400 };` it is logged as `warning`.

The two should be the same logging-wise to reduce confusion