### PR TITLE
feat: promote Request END (non-5xx) from debug to info

### DIFF
--- a/host/http.ts
+++ b/host/http.ts
@@ -92,9 +92,9 @@ export async function executeRequest(
             },
         })
         if (response.status >= 500) {
-            log.error('Request END')            
+            log.error('Request END')
         } else {
-            log.debug('Request END')
+            log.info('Request END')
         }
 
         if (response.status < 300) {
@@ -108,7 +108,7 @@ export async function executeRequest(
             if (response.status >= 500) {
                 log.error('Request END', e)
             } else {
-                log.debug('Request END')
+                log.info('Request END')
             }
 
             // If we do not want to rethrow errors, ie. for production environments,


### PR DESCRIPTION
## Summary

- Promotes `log.debug('Request END')` → `log.info('Request END')` for non-5xx responses (two call sites in `host/http.ts`)
- 5xx case stays at `error`; `Request BEGIN` stays at `trace`

## Why

Per US-9119, we're introducing a `LOG_LEVEL` env-var floor across the Riddance services with `LOG_LEVEL=info` in prod. The `Request END` entry is the single per-request lifecycle marker worth preserving in prod (it carries the enriched response status/headers/body). Keeping it at `debug` would force every prod service to either run at `debug` floor (more noise) or lose the entry entirely under `info`. Promoting to `info` makes the `info` floor viable.

## Test plan

- [ ] Visual diff review — change is mechanical (`debug` → `info`, 2 lines).
- [ ] After consuming via `node-aws-host` v0.2.6 in glue, verify in Dash0 that `Request END` appears at `level=info` for 2xx/3xx/4xx and `level=error` for 5xx.

## Notes

- No test added: repo has no test infrastructure (no `test/` dir, no test script in `package.json`). Setting up test infra is its own undertaking; not in scope for a 3-line behavior change. Confirmed v0.0.19→v0.0.20 didn't add tests either.
- Pre-existing TS error on main (`host/registry.ts:89` `replaceAll`/lib target) is unrelated to this PR.

Linear: https://linear.app/understory-io/issue/US-9119

🤖 Generated with [Claude Code](https://claude.com/claude-code)