### PR TITLE
chore: bump version to 0.0.22 to match git tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@riddance/host",
-  "version": "0.0.20",
+  "version": "0.0.22",
   "type": "module",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary

Bumps `package.json` version from `0.0.20` to `0.0.22`. Skipping `0.0.21` because that tag already exists in this repo with the old version field, and retagging would mutate history.

## Why

The `version` field has been out of sync with git tags for several releases (`v0.0.19`, `v0.0.20`, `v0.0.21` all carry `"version": "0.0.20"` in their package.json). For npm dependencies declared as **git URLs with tags** (which is how node-host is consumed by node-service and node-aws-host), npm uses the manifest's `version` string as the dedup key — not the git SHA. So an install targeting `#v0.0.21` reads the package.json at that commit, sees `"version": "0.0.20"`, and dedupes against any cached/locked v0.0.20 entry — silently reusing the older code.

Discovered while investigating why US-9119's `api-bookings` redeploy bundled `node-host v0.0.12` instead of `v0.0.21` despite the new wrapper pinning the latter. npm's debug log showed:

```
silly fetch manifest @riddance/host@git@github.com:understory-io/node-host#v0.0.21
silly placeDep ROOT @riddance/host@0.0.20 OK for: @riddance/service@0.1.14 want: git@github.com:understory-io/node-host#v0.0.21
```

After this PR ships, the next tag (`v0.0.22`) will be installed correctly because the version string in its manifest will be unique.

## Going forward

Two cleanup options for follow-up; not in scope for this PR:

- Add a check (`npm version <bump>` or a release script) that enforces version-field/tag alignment.
- Backfill correct version fields into older tags — only worth it if anything else still pins them.

## Test plan

- [ ] Tag merge as `v0.0.22`.
- [ ] Consume from `node-service` (will be bumped in a follow-up PR) and verify `npm install` resolves `@riddance/host` to the new SHA with `"version": "0.0.22"` in the lock.

Linear: https://linear.app/understory-io/issue/US-9119

🤖 Generated with [Claude Code](https://claude.com/claude-code)